### PR TITLE
change regexName to regex_name for consistency with other options

### DIFF
--- a/src/main/java/org/embulk/parser/regex/RegexParserPlugin.java
+++ b/src/main/java/org/embulk/parser/regex/RegexParserPlugin.java
@@ -100,7 +100,7 @@ public class RegexParserPlugin implements ParserPlugin {
             String name = c.getName();
             Type type = c.getType();
             Column column = c.toColumn(index);
-            String regexName = c.getOption().get(String.class, "regexName", name);
+            String regexName = c.getOption().get(String.class, "regex_name", name);
 
             DefaultValueSetter defaultValue = new NullDefaultValueSetter();
             DynamicColumnSetter setter;


### PR DESCRIPTION
Great plugin!
This is a simple pull-request that changes option name from `regexName` to `regex_name` for consistency with other options such as `skip_if_unmatch`.
