### PR TITLE
run method throws DataException if it found invalid record

### DIFF
--- a/src/main/java/org/embulk/parser/regex/RegexParserPlugin.java
+++ b/src/main/java/org/embulk/parser/regex/RegexParserPlugin.java
@@ -70,7 +70,7 @@ public class RegexParserPlugin implements ParserPlugin {
                         // TODO: How to Log?
                         continue;
                     } else {
-                        throw new RuntimeException("Unmatched Line: " + line);
+                        throw new DataException("Unmatched Line: " + line);
                     }
                 }
 


### PR DESCRIPTION
Embulk has 2 special exceptions: ConfigException and DataException. Both
of them implements UserDataException that means that the cause is
deterministic unless user input changes. In other words, retrying
doesn't help. This is useful when we embed Embulk in an application and
retry failed bulk load automatically for reliability.
