### PR TITLE
declare {source,target}Compatibility = 1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ configurations {
 
 version = "0.2.0"
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 dependencies {
     compile  "org.embulk:embulk-core:0.7.4"
     provided "org.embulk:embulk-core:0.7.4"


### PR DESCRIPTION
It's better to specify same versions as Embulk itself
